### PR TITLE
Add support for configurable font sizes in Obsidian 0.12

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -4,7 +4,7 @@
   --default-font: "Inter", sans-serif;
   --font-monospace: "Jetbrains Mono", monospace;
 
-  --font-editor-size: 11pt;
+  --font-editor-size: 1em;
   --font-editor-linenumbers-size: medium;
 
   --font-h1-preview-size: 2em;
@@ -13,10 +13,10 @@
   --font-h4-preview-size: 1em;
   --font-h5-preview-size: 0.875em;
   --font-h6-preview-size: 0.85em;
-  --font-math-preview-size: 18px;
+  --font-math-preview-size: 1.126em;
   --font-tag-preview-size: 9pt;
   --font-hover-preview-size: 0.9em;
-  --font-prompts-size: 14px;
+  --font-prompts-size: 0.875em;
 
   --font-todoist-title-size: 1em;
   --font-todoist-metadata-size: small;


### PR DESCRIPTION
As suggested by Obsidian developers, theme should not use absolute pixel values anymore for `font-size`. With this PR I converted three absolute `px` font sizes into `em`.