### PR TITLE
Add support for configurable font sizes in Obsidian 0.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### 🔁 Changes
  
 - Changed the style of headers in PDF export mode
+- All font sizes use `em` units. This allows users to configure the font size more easily.
 
 ### 🐛 Bugfixes
 

--- a/obsidian.css
+++ b/obsidian.css
@@ -2,7 +2,7 @@
 :root {
   --default-font: "Inter", sans-serif;
   --font-monospace: "Jetbrains Mono", monospace;
-  --font-editor-size: 11pt;
+  --font-editor-size: 1em;
   --font-editor-linenumbers-size: medium;
   --font-h1-preview-size: 2em;
   --font-h2-preview-size: 1.5em;
@@ -10,10 +10,10 @@
   --font-h4-preview-size: 1em;
   --font-h5-preview-size: 0.875em;
   --font-h6-preview-size: 0.85em;
-  --font-math-preview-size: 18px;
-  --font-tag-preview-size: 9pt;
+  --font-math-preview-size: 1.126em;
+  --font-tag-preview-size: 0.9em;
   --font-hover-preview-size: 0.9em;
-  --font-prompts-size: 14px;
+  --font-prompts-size: 0.875em;
   --font-todoist-title-size: 1em;
   --font-todoist-metadata-size: small;
 }

--- a/src/index.scss
+++ b/src/index.scss
@@ -14,7 +14,7 @@
   --font-h5-preview-size: 0.875em;
   --font-h6-preview-size: 0.85em;
   --font-math-preview-size: 1.126em;
-  --font-tag-preview-size: 9pt;
+  --font-tag-preview-size: 0.9em;
   --font-hover-preview-size: 0.9em;
   --font-prompts-size: 0.875em;
 

--- a/src/index.scss
+++ b/src/index.scss
@@ -4,7 +4,7 @@
   --default-font: "Inter", sans-serif;
   --font-monospace: "Jetbrains Mono", monospace;
 
-  --font-editor-size: 11pt;
+  --font-editor-size: 1em;
   --font-editor-linenumbers-size: medium;
 
   --font-h1-preview-size: 2em;
@@ -13,10 +13,10 @@
   --font-h4-preview-size: 1em;
   --font-h5-preview-size: 0.875em;
   --font-h6-preview-size: 0.85em;
-  --font-math-preview-size: 18px;
+  --font-math-preview-size: 1.126em;
   --font-tag-preview-size: 9pt;
   --font-hover-preview-size: 0.9em;
-  --font-prompts-size: 14px;
+  --font-prompts-size: 0.875em;
 
   --font-todoist-title-size: 1em;
   --font-todoist-metadata-size: small;


### PR DESCRIPTION
Duplicate of #39, with a few tweaks + checked in compiled CSS + changelog 