### PR TITLE
Fix h3 preview size

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -6,7 +6,7 @@
   --font-editor-linenumbers-size: medium;
   --font-h1-preview-size: 2em;
   --font-h2-preview-size: 1.5em;
-  --font-h3-preview-size: 1.25;
+  --font-h3-preview-size: 1.25em;
   --font-h4-preview-size: 1em;
   --font-h5-preview-size: 0.875em;
   --font-h6-preview-size: 0.85em;

--- a/src/index.scss
+++ b/src/index.scss
@@ -9,7 +9,7 @@
 
   --font-h1-preview-size: 2em;
   --font-h2-preview-size: 1.5em;
-  --font-h3-preview-size: 1.25;
+  --font-h3-preview-size: 1.25em;
   --font-h4-preview-size: 1em;
   --font-h5-preview-size: 0.875em;
   --font-h6-preview-size: 0.85em;


### PR DESCRIPTION
As pointed out in #51, the size value for `h3` headings are missing the unit.
This commit adds the unit `em` analogous to all other headings.

Fixes #51