### PR TITLE
Add highlighting for comments in editor

### DIFF
--- a/src/modules/editor/index.scss
+++ b/src/modules/editor/index.scss
@@ -53,6 +53,10 @@
     color: $light-red;
   }
 
+  .cm-comment {
+    color: $indigo !important;
+  }
+
   span.cm-inline-code {
     color: $cyan;
     font-size: inherit;


### PR DESCRIPTION
This aims to fix #49 but does not yet generate `obsidian.css`