### PR TITLE
Fix black-on-dark <hr/> in editor

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -98,6 +98,10 @@
 .cm-s-obsidian .cm-strong {
   color: #ff98a4;
 }
+.cm-s-obsidian hr {
+  border: none;
+  border-top: 2px solid rgba(122, 136, 207, 0.3);
+}
 .cm-s-obsidian span.cm-inline-code {
   color: #86e1fc;
   font-size: inherit;

--- a/src/modules/editor/index.scss
+++ b/src/modules/editor/index.scss
@@ -53,6 +53,11 @@
     color: $light-red;
   }
 
+  hr {
+    border: none;
+    border-top: 2px solid rgba($indigo, 0.3);
+  }
+
   span.cm-inline-code {
     color: $cyan;
     font-size: inherit;


### PR DESCRIPTION
Current editor is black, and it's hard to see in the editor view.

Could possibly be simplified since the hr styles are now the same between `preview/index.scss` and `editor/index.scss`.